### PR TITLE
Remove DataList from PlayerRelationships

### DIFF
--- a/src/main/java/be/swsb/pubgclient/PubgApiClient.java
+++ b/src/main/java/be/swsb/pubgclient/PubgApiClient.java
@@ -1,12 +1,14 @@
 package be.swsb.pubgclient;
 
 import be.swsb.pubgclient.api.PubgApiCaller;
+import be.swsb.pubgclient.gson.PlayerRelationshipsAdapter;
 import be.swsb.pubgclient.model.match.MatchResponse;
 import be.swsb.pubgclient.model.match.ParticipantRosterAsset;
 import be.swsb.pubgclient.model.match.asset.Asset;
 import be.swsb.pubgclient.model.match.participant.Participant;
 import be.swsb.pubgclient.model.match.roster.Roster;
 import be.swsb.pubgclient.model.player.Player;
+import be.swsb.pubgclient.model.player.PlayerRelationships;
 import be.swsb.pubgclient.model.player.PlayerResponse;
 import be.swsb.pubgclient.model.player.PlayersResponse;
 import com.google.gson.Gson;
@@ -86,6 +88,8 @@ public class PubgApiClient {
     private Gson getGson() {
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.registerTypeAdapter(ZonedDateTime.class, getZonedDateTimeJsonDeserializer());
+        PlayerRelationshipsAdapter typeAdapter = new PlayerRelationshipsAdapter(null);
+        gsonBuilder.registerTypeAdapter(PlayerRelationships.class, typeAdapter);
         gsonBuilder.registerTypeAdapter(ParticipantRosterAsset.class, (JsonDeserializer<ParticipantRosterAsset>) (json, typeOfT, context) -> {
             String type = json.getAsJsonObject().get("type").getAsString();
             if (type.equals("participant")) {
@@ -99,7 +103,10 @@ public class PubgApiClient {
             }
             throw new IllegalArgumentException("Unknown type for " + ParticipantRosterAsset.class.getSimpleName() + " deserialization: " + type);
         });
-        return gsonBuilder.create();
+        Gson gson = gsonBuilder.create();
+        //TODO lose depependency on gson by using JsonSerialize/JsonDeserializer
+        typeAdapter.setGson(gson);
+        return gson;
     }
 
     private JsonDeserializer<ZonedDateTime> getZonedDateTimeJsonDeserializer() {

--- a/src/main/java/be/swsb/pubgclient/PubgApiClient.java
+++ b/src/main/java/be/swsb/pubgclient/PubgApiClient.java
@@ -104,7 +104,7 @@ public class PubgApiClient {
             throw new IllegalArgumentException("Unknown type for " + ParticipantRosterAsset.class.getSimpleName() + " deserialization: " + type);
         });
         Gson gson = gsonBuilder.create();
-        //TODO lose depependency on gson by using JsonSerialize/JsonDeserializer
+        //TODO lose dependency on gson by using JsonSerialize/JsonDeserializer
         typeAdapter.setGson(gson);
         return gson;
     }

--- a/src/main/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapter.java
+++ b/src/main/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapter.java
@@ -1,6 +1,5 @@
 package be.swsb.pubgclient.gson;
 
-import be.swsb.pubgclient.model.DataList;
 import be.swsb.pubgclient.model.player.MatchId;
 import be.swsb.pubgclient.model.player.PlayerRelationships;
 import com.google.gson.Gson;
@@ -63,10 +62,9 @@ public class PlayerRelationshipsAdapter extends TypeAdapter<PlayerRelationships>
         writer.name("data");
         writer.beginArray();
 
-        DataList<MatchId> matchIds = playerRelationships.getMatchIds();
-        List<MatchId> matchIdsData = matchIds.getData();
-        if(matchIdsData != null) {
-            matchIdsData.forEach((matchId) -> writeMatchId(writer, matchId));
+        List<MatchId> matchIds = playerRelationships.getMatchIds();
+        if(matchIds != null) {
+            matchIds.forEach((matchId) -> writeMatchId(writer, matchId));
         }
 
         writer.endArray();
@@ -111,7 +109,7 @@ public class PlayerRelationshipsAdapter extends TypeAdapter<PlayerRelationships>
         while (reader.hasNext()) {
             readMatch(reader, matchIds);
         }
-        playerRelationships.setMatchIds(new DataList<>(matchIds));
+        playerRelationships.setMatchIds(new ArrayList<>(matchIds));
         reader.endArray();
         reader.endObject();
     }

--- a/src/main/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapter.java
+++ b/src/main/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapter.java
@@ -1,0 +1,115 @@
+package be.swsb.pubgclient.gson;
+
+import be.swsb.pubgclient.model.DataList;
+import be.swsb.pubgclient.model.player.MatchId;
+import be.swsb.pubgclient.model.player.PlayerRelationships;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.TypeAdapter;
+import com.google.gson.internal.Streams;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.List;
+
+public class PlayerRelationshipsAdapter extends TypeAdapter<PlayerRelationships> {
+
+    private final Gson gson;
+
+    public PlayerRelationshipsAdapter(Gson gson) {
+        this.gson = gson;
+    }
+
+
+    @Override
+    public void write(JsonWriter writer, PlayerRelationships playerRelationships) throws IOException {
+        if (playerRelationships == null) {
+            writer.nullValue();
+        } else {
+            writer.setIndent("  ");
+            writer.beginObject();
+            writeAssets(writer);
+            writeMatchIds(writer, playerRelationships);
+            writer.endObject();
+        }
+
+    }
+
+    private void writeAssets(JsonWriter writer) throws IOException {
+        writer
+            .name("assets")
+            .beginObject()
+                .name("data")
+                .beginArray()
+                .endArray()
+            .endObject();
+}
+
+    private void writeMatchIds(JsonWriter writer, PlayerRelationships playerRelationships) throws IOException {
+        writer.name("matches");
+        writer.beginObject();
+        writer.name("data");
+        writer.beginArray();
+
+        DataList<MatchId> matchIds = playerRelationships.getMatchIds();
+        List<MatchId> matchIdsData = matchIds.getData();
+        if(matchIdsData != null) {
+            matchIdsData.forEach((matchId) -> writeMatchId(writer, matchId));
+        }
+
+        writer.endArray();
+        writer.endObject();
+    }
+
+    private void writeMatchId(JsonWriter writer, MatchId matchId) {
+        try {
+            JsonElement jsonElement = gson.toJsonTree(matchId);
+            jsonElement.getAsJsonObject().addProperty("type", "match");
+            Streams.write(jsonElement, writer);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public PlayerRelationships read(JsonReader reader) throws IOException {
+        if(reader.peek() == null) {
+            reader.nextNull();
+            return null;
+        }
+        PlayerRelationships playerRelationships = new PlayerRelationships();
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "assets": readAssets(reader, playerRelationships); break;
+                case "matches": readMaches(reader, playerRelationships); break;
+            }
+        }
+        reader.endObject();
+        return playerRelationships;
+    }
+
+    private void readMaches(JsonReader reader, PlayerRelationships playerRelationships) throws IOException {
+        reader.beginObject();
+        reader.nextName();
+        reader.beginArray();
+        while (reader.hasNext()) {
+            reader.skipValue();
+        }
+        reader.endArray();
+        reader.endObject();
+    }
+
+
+    private void readAssets(JsonReader reader, PlayerRelationships playerRelationships) throws IOException {
+        reader.beginObject();
+        reader.nextName();
+        reader.beginArray();
+        while (reader.hasNext()) {
+            reader.skipValue();
+        }
+        reader.endArray();
+        reader.endObject();
+    }
+}

--- a/src/main/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapter.java
+++ b/src/main/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapter.java
@@ -11,11 +11,21 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class PlayerRelationshipsAdapter extends TypeAdapter<PlayerRelationships> {
 
-    private final Gson gson;
+    public Gson getGson() {
+        return gson;
+    }
+
+    public void setGson(Gson gson) {
+        this.gson = gson;
+    }
+
+    private Gson gson;
 
     public PlayerRelationshipsAdapter(Gson gson) {
         this.gson = gson;
@@ -24,6 +34,7 @@ public class PlayerRelationshipsAdapter extends TypeAdapter<PlayerRelationships>
 
     @Override
     public void write(JsonWriter writer, PlayerRelationships playerRelationships) throws IOException {
+        Objects.requireNonNull(gson, "Gson must be set before calling this adapter");
         if (playerRelationships == null) {
             writer.nullValue();
         } else {
@@ -82,8 +93,10 @@ public class PlayerRelationshipsAdapter extends TypeAdapter<PlayerRelationships>
         reader.beginObject();
         while (reader.hasNext()) {
             switch (reader.nextName()) {
-                case "assets": readAssets(reader, playerRelationships); break;
-                case "matches": readMaches(reader, playerRelationships); break;
+                case "assets":  readAssets(reader, playerRelationships);
+                                break;
+                case "matches": readMaches(reader, playerRelationships);
+                                break;
             }
         }
         reader.endObject();
@@ -94,10 +107,26 @@ public class PlayerRelationshipsAdapter extends TypeAdapter<PlayerRelationships>
         reader.beginObject();
         reader.nextName();
         reader.beginArray();
+        List<MatchId> matchIds = new ArrayList<>();
         while (reader.hasNext()) {
-            reader.skipValue();
+            readMatch(reader, matchIds);
         }
+        playerRelationships.setMatchIds(new DataList<>(matchIds));
         reader.endArray();
+        reader.endObject();
+    }
+
+    private void readMatch(JsonReader reader, List<MatchId> matchIds) throws IOException {
+        reader.beginObject();
+        while (reader.hasNext()) {
+            switch (reader.nextName()) {
+                case "type":    reader.skipValue();
+                                break;
+                case "id":
+                            matchIds.add(new MatchId(reader.nextString()));
+                            break;
+            }
+        }
         reader.endObject();
     }
 

--- a/src/main/java/be/swsb/pubgclient/model/DataList.java
+++ b/src/main/java/be/swsb/pubgclient/model/DataList.java
@@ -1,9 +1,19 @@
 package be.swsb.pubgclient.model;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 // TODO improve this, make this class go away?
 public class DataList<T> {
+
+    public DataList(){
+        this(new ArrayList<>());
+    }
+
+    public DataList(List<T> data){
+        this.data = data;
+    }
 
     private List<T> data;
 
@@ -16,6 +26,21 @@ public class DataList<T> {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DataList<?> dataList = (DataList<?>) o;
+        return Objects.equals(data, dataList.data);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(data);
+    }
+
+    @Override
+
     public String toString() {
         return "DataList{" +
                 "data=" + data +

--- a/src/main/java/be/swsb/pubgclient/model/player/MatchId.java
+++ b/src/main/java/be/swsb/pubgclient/model/player/MatchId.java
@@ -1,6 +1,15 @@
 package be.swsb.pubgclient.model.player;
 
+import java.util.Objects;
+
 public class MatchId {
+
+    private MatchId() {
+    }
+
+    public MatchId(String id) {
+        this.id = id;
+    }
 
     private String id;
 
@@ -17,5 +26,19 @@ public class MatchId {
         return "MatchId{" +
                 "id='" + id + '\'' +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MatchId matchId = (MatchId) o;
+        return Objects.equals(id, matchId.id);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/be/swsb/pubgclient/model/player/PlayerRelationships.java
+++ b/src/main/java/be/swsb/pubgclient/model/player/PlayerRelationships.java
@@ -3,21 +3,46 @@ package be.swsb.pubgclient.model.player;
 import be.swsb.pubgclient.model.DataList;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.Objects;
+
 public class PlayerRelationships {
 
-    // TODO find a way to retrieve matchIds as a String here without the intermediate object
-    @SerializedName("matches")
-    private DataList<MatchId> matchIds;
+    public PlayerRelationships() {
+        this(new DataList<>());
+    }
+
+    public PlayerRelationships(DataList<MatchId> matchIds) {
+        this.matchIds = matchIds;
+    }
 
     public DataList<MatchId> getMatchIds() {
         return matchIds;
     }
+    // TODO find a way to retrieve matchIds as a String here without the intermediate object
+
+    @SerializedName("matches")
+    private DataList<MatchId> matchIds;
 
     public void setMatchIds(DataList<MatchId> matchIds) {
         this.matchIds = matchIds;
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PlayerRelationships that = (PlayerRelationships) o;
+        return Objects.equals(matchIds, that.matchIds);
+    }
+
+    @Override
+    public int hashCode() {
+
+        return Objects.hash(matchIds);
+    }
+
+    @Override
+
     public String toString() {
         return "PlayerRelationships{" +
                 "matchIds=" + matchIds +

--- a/src/main/java/be/swsb/pubgclient/model/player/PlayerRelationships.java
+++ b/src/main/java/be/swsb/pubgclient/model/player/PlayerRelationships.java
@@ -1,29 +1,29 @@
 package be.swsb.pubgclient.model.player;
 
-import be.swsb.pubgclient.model.DataList;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 public class PlayerRelationships {
 
+    @SerializedName("matches")
+    private List<MatchId> matchIds;
+
     public PlayerRelationships() {
-        this(new DataList<>());
+        this(new ArrayList<>());
     }
 
-    public PlayerRelationships(DataList<MatchId> matchIds) {
+    public PlayerRelationships(List<MatchId> matchIds) {
         this.matchIds = matchIds;
     }
-
-    public DataList<MatchId> getMatchIds() {
+    public List<MatchId> getMatchIds() {
         return matchIds;
     }
     // TODO find a way to retrieve matchIds as a String here without the intermediate object
 
-    @SerializedName("matches")
-    private DataList<MatchId> matchIds;
-
-    public void setMatchIds(DataList<MatchId> matchIds) {
+    public void setMatchIds(List<MatchId> matchIds) {
         this.matchIds = matchIds;
     }
 
@@ -42,7 +42,6 @@ public class PlayerRelationships {
     }
 
     @Override
-
     public String toString() {
         return "PlayerRelationships{" +
                 "matchIds=" + matchIds +

--- a/src/test/java/be/swsb/pubgclient/AbstractUnitTest.java
+++ b/src/test/java/be/swsb/pubgclient/AbstractUnitTest.java
@@ -1,0 +1,27 @@
+package be.swsb.pubgclient;
+
+import org.junit.Rule;
+import org.mockito.junit.MockitoRule;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Paths.get;
+import static java.util.Objects.requireNonNull;
+import static org.mockito.junit.MockitoJUnit.rule;
+
+public class AbstractUnitTest {
+
+    @Rule
+    public MockitoRule rule = rule();
+
+
+    protected String readFile(String path) {
+        try {
+            return new String(readAllBytes(get(requireNonNull(PubgApiClientTest.class.getClassLoader().getResource(path)).toURI())));
+        } catch (IOException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/be/swsb/pubgclient/PubgApiClientTest.java
+++ b/src/test/java/be/swsb/pubgclient/PubgApiClientTest.java
@@ -58,7 +58,7 @@ public class PubgApiClientTest {
     }
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         pubgApiClient.setPubgApiCaller(pubgApiCaller);
     }
 

--- a/src/test/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapterTest.java
+++ b/src/test/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapterTest.java
@@ -1,0 +1,81 @@
+package be.swsb.pubgclient.gson;
+
+import be.swsb.pubgclient.AbstractUnitTest;
+import be.swsb.pubgclient.model.DataList;
+import be.swsb.pubgclient.model.player.MatchId;
+import be.swsb.pubgclient.model.player.PlayerRelationships;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.google.gson.internal.bind.JsonTreeReader;
+import com.google.gson.internal.bind.JsonTreeWriter;
+import com.google.gson.stream.JsonReader;
+import org.assertj.core.util.Lists;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PlayerRelationshipsAdapterTest extends AbstractUnitTest {
+
+
+    private PlayerRelationshipsAdapter playerRelationshipsAdapter;
+    private JsonTreeWriter jsonWriter;
+    private JsonReader jsonReader;
+    private JsonParser jsonParser;
+    private FileReader fileReader;
+    private PlayerRelationships playerRelationships;
+    private Gson gson;
+    private MatchId matchId1;
+    private MatchId matchId2;
+
+    @Before
+    public void setUp() {
+        jsonWriter = new JsonTreeWriter();
+        jsonParser = new JsonParser();
+        gson = new Gson();
+        playerRelationshipsAdapter = new PlayerRelationshipsAdapter(gson);
+        playerRelationships = new PlayerRelationships();
+        matchId1 = new MatchId();
+        matchId2 = new MatchId();
+    }
+
+
+    @Test
+    public void write_whenEmptyMatches_thenCreateJsonWithEmptyMatchesData() {
+        String file = readFile("relationships_samples/emptyMatches.json");
+        JsonElement expectedJsonElement = jsonParser.parse(file);
+        JsonElement actualJsonElement = playerRelationshipsAdapter.toJsonTree(playerRelationships);
+
+        assertThat(actualJsonElement).isEqualTo(expectedJsonElement);
+    }
+
+    @Test
+    public void write_whenTwoMatchesPresent_thenCreateJsonWithTwoMatches() {
+        matchId1.setId("439b4e90-f9ea-49ef-bf62-00241492dffe");
+        matchId2.setId("9a6459d0-5b58-476f-9111-29893a794d67");
+        ArrayList<MatchId> matchIds = Lists.newArrayList(matchId1, matchId2);
+        playerRelationships.setMatchIds(new DataList<>(matchIds));
+
+        String file = readFile("relationships_samples/twoMatches.json");
+        JsonElement expectedJsonElement = jsonParser.parse(file);
+        JsonElement actualJsonElement = playerRelationshipsAdapter.toJsonTree(playerRelationships);
+
+        assertThat(actualJsonElement).isEqualTo(expectedJsonElement);
+    }
+
+    @Test
+    public void read_whenEmptyMatches_thenCreatePlayerRelationshipsWithNoMatchIds() throws IOException {
+        String file = readFile("relationships_samples/emptyMatches.json");
+        jsonReader = new JsonTreeReader(jsonParser.parse(file));
+        PlayerRelationships expected = new PlayerRelationships();
+
+        PlayerRelationships actual = playerRelationshipsAdapter.read(jsonReader);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/src/test/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapterTest.java
+++ b/src/test/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapterTest.java
@@ -1,7 +1,6 @@
 package be.swsb.pubgclient.gson;
 
 import be.swsb.pubgclient.AbstractUnitTest;
-import be.swsb.pubgclient.model.DataList;
 import be.swsb.pubgclient.model.player.MatchId;
 import be.swsb.pubgclient.model.player.PlayerRelationships;
 import com.google.gson.Gson;
@@ -59,7 +58,7 @@ public class PlayerRelationshipsAdapterTest extends AbstractUnitTest {
         matchId1.setId("439b4e90-f9ea-49ef-bf62-00241492dffe");
         matchId2.setId("9a6459d0-5b58-476f-9111-29893a794d67");
         ArrayList<MatchId> matchIds = Lists.newArrayList(matchId1, matchId2);
-        playerRelationships.setMatchIds(new DataList<>(matchIds));
+        playerRelationships.setMatchIds(new ArrayList<>(matchIds));
 
         String file = readFile("relationships_samples/twoMatches.json");
         JsonElement expectedJsonElement = jsonParser.parse(file);
@@ -84,7 +83,7 @@ public class PlayerRelationshipsAdapterTest extends AbstractUnitTest {
         matchId1.setId("439b4e90-f9ea-49ef-bf62-00241492dffe");
         matchId2.setId("9a6459d0-5b58-476f-9111-29893a794d67");
         ArrayList<MatchId> matchIds = Lists.newArrayList(matchId1, matchId2);
-        playerRelationships.setMatchIds(new DataList<>(matchIds));
+        playerRelationships.setMatchIds(new ArrayList<>(matchIds));
         String file = readFile("relationships_samples/twoMatches.json");
         jsonReader = new JsonTreeReader(jsonParser.parse(file));
 

--- a/src/test/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapterTest.java
+++ b/src/test/java/be/swsb/pubgclient/gson/PlayerRelationshipsAdapterTest.java
@@ -40,8 +40,8 @@ public class PlayerRelationshipsAdapterTest extends AbstractUnitTest {
         gson = new Gson();
         playerRelationshipsAdapter = new PlayerRelationshipsAdapter(gson);
         playerRelationships = new PlayerRelationships();
-        matchId1 = new MatchId();
-        matchId2 = new MatchId();
+        matchId1 = new MatchId("id1");
+        matchId2 = new MatchId("id2");
     }
 
 
@@ -77,5 +77,32 @@ public class PlayerRelationshipsAdapterTest extends AbstractUnitTest {
         PlayerRelationships actual = playerRelationshipsAdapter.read(jsonReader);
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void read_whenTwoMatchesPresent_thenCreatePlayerRelationShipsWithTwoMatches() throws IOException {
+        matchId1.setId("439b4e90-f9ea-49ef-bf62-00241492dffe");
+        matchId2.setId("9a6459d0-5b58-476f-9111-29893a794d67");
+        ArrayList<MatchId> matchIds = Lists.newArrayList(matchId1, matchId2);
+        playerRelationships.setMatchIds(new DataList<>(matchIds));
+        String file = readFile("relationships_samples/twoMatches.json");
+        jsonReader = new JsonTreeReader(jsonParser.parse(file));
+
+        PlayerRelationships actual = playerRelationshipsAdapter.read(jsonReader);
+
+        assertThat(actual).isEqualTo(playerRelationships);
+    }
+
+    @Test
+    public void readWrite_shouldReturnSameJson() throws IOException {
+
+        String file = readFile("relationships_samples/fiveMatches.json");
+        JsonElement expectedJsonElement = jsonParser.parse(file);
+
+        jsonReader = new JsonTreeReader(expectedJsonElement);
+        PlayerRelationships read = playerRelationshipsAdapter.read(jsonReader);
+        JsonElement actualJsonElement = playerRelationshipsAdapter.toJsonTree(read);
+
+        assertThat(actualJsonElement).isEqualTo(expectedJsonElement);
     }
 }

--- a/src/test/resources/relationships_samples/emptyMatches.json
+++ b/src/test/resources/relationships_samples/emptyMatches.json
@@ -1,0 +1,9 @@
+{
+  "assets": {
+    "data": []
+  },
+  "matches": {
+    "data": [
+    ]
+  }
+}

--- a/src/test/resources/relationships_samples/fiveMatches.json
+++ b/src/test/resources/relationships_samples/fiveMatches.json
@@ -1,0 +1,29 @@
+{
+  "matches": {
+    "data": [
+      {
+        "type": "match",
+        "id": "439b4e90-f9ea-49ef-bf62-00241492dffe"
+      },
+      {
+        "type": "match",
+        "id": "9a6459d0-5b58-476f-9111-29893a794d67"
+      },
+      {
+        "type": "match",
+        "id": "cc1c7be9-ba7a-45bc-9257-4089ca543889"
+      },
+      {
+        "type": "match",
+        "id": "50867f48-d640-4e19-b48f-b4f72ce07447"
+      },
+      {
+        "type": "match",
+        "id": "ed9f46c0-5733-482f-bb69-f60b21fc2846"
+      }
+    ]
+  },
+  "assets": {
+    "data": []
+  }
+}

--- a/src/test/resources/relationships_samples/twoMatches.json
+++ b/src/test/resources/relationships_samples/twoMatches.json
@@ -1,0 +1,17 @@
+{
+  "matches": {
+    "data": [
+      {
+        "type": "match",
+        "id": "439b4e90-f9ea-49ef-bf62-00241492dffe"
+      },
+      {
+        "type": "match",
+        "id": "9a6459d0-5b58-476f-9111-29893a794d67"
+      }
+    ]
+  },
+  "assets": {
+    "data": []
+  }
+}


### PR DESCRIPTION
I created a custom TypeAdapter for the PlayerRelationships so we no longer need the DataList as a wrapper around the MatchIds as this doesn't add any value.

Some potential points for improvement:
- Currently the PlayerRelationshipsTypeAdapter needs a reference to a Gson instance which makes for some ugly instanciation in the GsonBuilder. This could probably be improved by switching to a JsonDeserializer/Serializer
- I wasn't sure in what package to put the new adapter so I created a new one
